### PR TITLE
Add links to project pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ Roll your own container or use the pre-set up ones:
  - [mongodb](sweet/factories/tc/mongodb)
  - [postgres](sweet/factories/tc/postgres)
  - [cockroachdb](sweet/factories/tc/cockroachdb)
+
+### Links
+ - [Project overview](https://barryhennessy.com/projects/test/)

--- a/sweet/README.md
+++ b/sweet/README.md
@@ -65,3 +65,6 @@ reused throughout every project.
 If you want to take some action without returning a dep you're free to.
 E.g: outputting some text, asserting some value (as usual with `testing.T`),
 waiting for a dependency to spin up and be ready.
+
+### Links
+ - [Project overview and background](https://barryhennessy.com/projects/test-sweet/)

--- a/sweet/factories/tc/README.md
+++ b/sweet/factories/tc/README.md
@@ -11,3 +11,6 @@ The containers
      ready
  - start tests as soon as they're ready to serve traffic
    - client tests should not be waiting because a factory is calling `time.Sleep`
+
+### Links
+ - [Project overview and related information](https://barryhennessy.com/projects/test-sweet-containers/)


### PR DESCRIPTION
The project pages will serve as a central location to gather cross-project details. How things work together, or should. Background information and potential future directions etc.