### PR TITLE
Log over erroring on testcontainer Cleanup

### DIFF
--- a/sweet/factories/tc/testcontainers.go
+++ b/sweet/factories/tc/testcontainers.go
@@ -29,7 +29,7 @@ func NewContainer(t *testing.T, ctx context.Context, c Container) testcontainers
 
 	t.Cleanup(func() {
 		if err := c.Close(ctx, container); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
+			t.Logf("failed to terminate container: %s", err)
 		}
 	})
 


### PR DESCRIPTION
The common error is that the context has closed when cleanup has run (`defer cancel()`). So the cleanup was unnecessarially failing otherwise perfectly good tests.